### PR TITLE
updates spec for piglatinizer results

### DIFF
--- a/spec/sinatra_mvc_lab_spec.rb
+++ b/spec/sinatra_mvc_lab_spec.rb
@@ -39,7 +39,7 @@ describe "Pig Latinizer App" do
     end
 
     it "displays the pig latinized phrase upon form submission" do
-      expect(last_response.body).to include("eOncay uponay a imetay and a eryvay oodgay imetay itay asway erethay asway a oocowmay omingcay ownday alongay ethay oadray and isthay oocowmay atthay asway omingcay ownday alongay ethay oadray etmay a icensnay ittlelay oybay amednay abybay uckootay")
+      expect(last_response.body).to include("Onceyay uponyay a imetay andyay a eryvay oodgay imetay ityay asway erethay asway a oocowmay omingcay ownday alongyay ethay oadray andyay isthay oocowmay atthay asway omingcay ownday alongyay ethay oadray etmay a icensnay ittlelay oybay amednay abybay uckootay")
     end
   end
 
@@ -55,7 +55,7 @@ describe "Pig Latinizer App" do
     end
 
     it "displays the pig latinized phrase upon form submission" do
-      expect(last_response.body).to include("eHay asway an olday anmay owhay ishedfay aloneay in a iffskay in ethay ulfGay eamStray and ehay adhay onegay eightyay ourfay aysday ownay ithoutway akingtay a ishfay")
+      expect(last_response.body).to include("eHay asway anyay oldyay anmay owhay ishedfay aloneyay inyay a iffskay inyay ethay ulfGay eamStray andyay ehay adhay onegay eightyyay ourfay aysday ownay ithoutway akingtay a ishfay")
     end
   end
 end


### PR DESCRIPTION
Correct Pig Latin adds a 'yay' to words that start with a vowel (upper or lowercase) not just 'ay'.
If just 'ay' were added, then converting back to English from Pig Latin would result in many errors (as there would be no way to tell whether the word originally started with a vowel or not).
This spec updates the expected results to consider that.  (I went off wikipedia for pig latin rules)